### PR TITLE
Improve README instructions and folder structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,9 +25,17 @@
 
 1. Download or clone this repo
 2. Open the folder in **Godot 4.2**
-3. Run the `Level1.tscn` scene
+3. In the Godot editor, run the `Level1.tscn` scene to start the game
+
+Levels are stored as individual scenes (`Level1.tscn`, `Level2.tscn`, and so on).
+Open a scene from the **FileSystem** dock to edit or test that level directly.
 
 ---
 
 ## 🛠️ Folder Structure
+
+The repository contains only a few essential directories:
+
+- `scripts/` – GDScript code for gameplay, UI, and enemy logic
+- `assets/`  – game assets such as sound files in `assets/audio/`
 


### PR DESCRIPTION
## Summary
- clarify how to run the Godot project
- describe how levels are organized
- fill in missing folder structure documentation

## Testing
- `git status --short`