### PR TITLE
Add level scenes and boss script

### DIFF
--- a/scenes/Boss.tscn
+++ b/scenes/Boss.tscn
@@ -1,0 +1,22 @@
+[gd_scene format=3]
+
+[ext_resource path="res://scripts/LevelManager.gd" type="Script" id="1"]
+[ext_resource path="res://scripts/MrPlus.gd" type="Script" id="2"]
+[ext_resource path="res://scripts/UI.gd" type="Script" id="3"]
+[ext_resource path="res://scripts/Boss.gd" type="Script" id="4"]
+
+[node name="BossLevel" type="Node2D"]
+script = ExtResource("1")
+
+[node name="MrPlus" type="CharacterBody2D" parent="."]
+script = ExtResource("2")
+
+[node name="UI" type="CanvasLayer" parent="."]
+script = ExtResource("3")
+
+[node name="Exit" type="Area2D" parent="."]
+
+[node name="Boss" type="CharacterBody2D" parent="."]
+script = ExtResource("4")
+
+[connection signal="body_entered" from="Exit" to="." method="on_exit_body_entered"]

--- a/scenes/Level1.tscn
+++ b/scenes/Level1.tscn
@@ -1,0 +1,22 @@
+[gd_scene format=3]
+
+[ext_resource path="res://scripts/LevelManager.gd" type="Script" id="1"]
+[ext_resource path="res://scripts/MrPlus.gd" type="Script" id="2"]
+[ext_resource path="res://scripts/UI.gd" type="Script" id="3"]
+[ext_resource path="res://scripts/Enemy.gd" type="Script" id="4"]
+
+[node name="Level1" type="Node2D"]
+script = ExtResource("1")
+
+[node name="MrPlus" type="CharacterBody2D" parent="."]
+script = ExtResource("2")
+
+[node name="UI" type="CanvasLayer" parent="."]
+script = ExtResource("3")
+
+[node name="Exit" type="Area2D" parent="."]
+
+[node name="Enemy" type="CharacterBody2D" parent="."]
+script = ExtResource("4")
+
+[connection signal="body_entered" from="Exit" to="." method="on_exit_body_entered"]

--- a/scenes/Level2.tscn
+++ b/scenes/Level2.tscn
@@ -1,0 +1,25 @@
+[gd_scene format=3]
+
+[ext_resource path="res://scripts/LevelManager.gd" type="Script" id="1"]
+[ext_resource path="res://scripts/MrPlus.gd" type="Script" id="2"]
+[ext_resource path="res://scripts/UI.gd" type="Script" id="3"]
+[ext_resource path="res://scripts/Enemy.gd" type="Script" id="4"]
+
+[node name="Level2" type="Node2D"]
+script = ExtResource("1")
+
+[node name="MrPlus" type="CharacterBody2D" parent="."]
+script = ExtResource("2")
+
+[node name="UI" type="CanvasLayer" parent="."]
+script = ExtResource("3")
+
+[node name="Exit" type="Area2D" parent="."]
+
+[node name="Enemy1" type="CharacterBody2D" parent="."]
+script = ExtResource("4")
+
+[node name="Enemy2" type="CharacterBody2D" parent="."]
+script = ExtResource("4")
+
+[connection signal="body_entered" from="Exit" to="." method="on_exit_body_entered"]

--- a/scenes/Level3.tscn
+++ b/scenes/Level3.tscn
@@ -1,0 +1,28 @@
+[gd_scene format=3]
+
+[ext_resource path="res://scripts/LevelManager.gd" type="Script" id="1"]
+[ext_resource path="res://scripts/MrPlus.gd" type="Script" id="2"]
+[ext_resource path="res://scripts/UI.gd" type="Script" id="3"]
+[ext_resource path="res://scripts/Enemy.gd" type="Script" id="4"]
+
+[node name="Level3" type="Node2D"]
+script = ExtResource("1")
+
+[node name="MrPlus" type="CharacterBody2D" parent="."]
+script = ExtResource("2")
+
+[node name="UI" type="CanvasLayer" parent="."]
+script = ExtResource("3")
+
+[node name="Exit" type="Area2D" parent="."]
+
+[node name="Enemy1" type="CharacterBody2D" parent="."]
+script = ExtResource("4")
+
+[node name="Enemy2" type="CharacterBody2D" parent="."]
+script = ExtResource("4")
+
+[node name="Enemy3" type="CharacterBody2D" parent="."]
+script = ExtResource("4")
+
+[connection signal="body_entered" from="Exit" to="." method="on_exit_body_entered"]

--- a/scripts/Boss.gd
+++ b/scripts/Boss.gd
@@ -1,0 +1,25 @@
+extends CharacterBody2D
+
+signal attack
+
+@export var speed := 40
+@export var attack_interval := 2.0
+
+var direction := 1
+var velocity := Vector2.ZERO
+var _timer := 0.0
+
+func _ready():
+    _timer = attack_interval
+
+func _physics_process(delta):
+    velocity.x = speed * direction
+    velocity = move_and_slide(velocity, Vector2.UP)
+
+    if is_on_wall():
+        direction *= -1
+
+    _timer -= delta
+    if _timer <= 0:
+        _timer = attack_interval
+        emit_signal("attack")

--- a/scripts/LevelManager.gd
+++ b/scripts/LevelManager.gd
@@ -1,5 +1,7 @@
 extends Node2D
 
+signal level_completed
+
 @onready var player := $MrPlus
 @onready var ui := $UI
 
@@ -12,3 +14,10 @@ func on_pipoca_collected():
 
 func on_player_hit():
     ui.remove_life()
+
+func complete_level():
+    emit_signal("level_completed")
+
+func on_exit_body_entered(body):
+    if body == player:
+        complete_level()


### PR DESCRIPTION
## Summary
- add `Boss.gd` script with simple movement and attack signal
- extend `LevelManager.gd` with completion signal
- create placeholder level scenes and boss level scene

## Testing
- `true`