### PR TITLE
Add unit test scaffolding and coverage

### DIFF
--- a/tests/test_enemy.gd
+++ b/tests/test_enemy.gd
@@ -1,0 +1,14 @@
+extends UnitTest
+
+var enemy
+
+func before_each():
+    enemy = preload("res://scripts/Enemy.gd").new()
+    enemy.move_and_slide = func(v, up := Vector2.UP):
+        return v
+
+func test_reverse_on_wall():
+    enemy.direction = -1
+    enemy.is_on_wall = func(): return true
+    enemy._physics_process(0.016)
+    assert_eq(enemy.direction, 1)

--- a/tests/test_level_manager.gd
+++ b/tests/test_level_manager.gd
@@ -1,0 +1,42 @@
+extends UnitTest
+
+class UIStub:
+    var score := 0
+    var lives := 0
+    var reload_called := false
+
+    func update_score(v):
+        score = v
+    func add_score(a):
+        score += a
+    func update_lives(v):
+        lives = v
+    func remove_life():
+        lives -= 1
+        if lives <= 0:
+            reload_called = true
+
+var manager
+
+func before_each():
+    manager = preload("res://scripts/LevelManager.gd").new()
+    manager.ui = UIStub.new()
+
+func test_ready_initializes_ui():
+    manager._ready()
+    assert_eq(manager.ui.lives, 3)
+    assert_eq(manager.ui.score, 0)
+
+func test_score_increment():
+    manager._ready()
+    manager.on_pipoca_collected()
+    assert_eq(manager.ui.score, 1)
+
+func test_life_decrement_and_reload():
+    manager._ready()
+    manager.on_player_hit()
+    assert_eq(manager.ui.lives, 2)
+    manager.on_player_hit()
+    assert_eq(manager.ui.lives, 1)
+    manager.on_player_hit()
+    assert_true(manager.ui.reload_called)

--- a/tests/test_mrplus.gd
+++ b/tests/test_mrplus.gd
@@ -1,0 +1,23 @@
+extends UnitTest
+
+var player
+
+func before_each():
+    player = preload("res://scripts/MrPlus.gd").new()
+    # override physics methods
+    player.move_and_slide = func(v, up := Vector2.UP):
+        return v
+
+func test_jump():
+    player.is_on_floor = func(): return true
+    Input.is_action_just_pressed = func(action):
+        return action == "ui_accept"
+    player._physics_process(0.016)
+    assert_eq(player.velocity.y, player.jump_force)
+
+func test_gravity():
+    player.is_on_floor = func(): return false
+    var start_y := player.velocity.y
+    var dt := 0.5
+    player._physics_process(dt)
+    assert_eq(player.velocity.y, start_y + player.gravity * dt)

--- a/tests/test_suite.gd
+++ b/tests/test_suite.gd
@@ -1,0 +1,6 @@
+extends TestSuite
+
+func _init():
+    add(preload("res://tests/test_mrplus.gd").new())
+    add(preload("res://tests/test_enemy.gd").new())
+    add(preload("res://tests/test_level_manager.gd").new())


### PR DESCRIPTION
## Summary
- set up Godot built-in unit tests under `tests/`
- cover `MrPlus.gd` jumping and gravity
- test `Enemy.gd` direction reversal on wall collision
- validate `LevelManager.gd` score/life logic

## Testing
- `godot --headless --run-tests` *(fails: `godot` not installed)*