### PR TITLE
Add boss defeat handling

### DIFF
--- a/scripts/LevelManager.gd
+++ b/scripts/LevelManager.gd
@@ -10,11 +10,14 @@ static var lives: int = 3
 
 @onready var player := $MrPlus
 @onready var ui := $UI
+@onready var boss := get_node_or_null("Boss")
 
 func _ready():
     # When a new level loads, sync the UI with the stored state
     ui.update_lives(lives)
     ui.update_score(score)
+    if boss:
+        boss.boss_defeated.connect(on_boss_defeated)
 
 func on_pipoca_collected():
     ui.add_score(1)
@@ -41,4 +44,7 @@ func load_next_level():
     get_tree().change_scene_to_file(next_scene_path)
 
 func on_level_completed():
+    load_next_level()
+
+func on_boss_defeated():
     load_next_level()

--- a/tests/test_level_manager.gd
+++ b/tests/test_level_manager.gd
@@ -16,6 +16,9 @@ class UIStub:
         if lives <= 0:
             reload_called = true
 
+class BossStub:
+    signal boss_defeated
+
 var manager
 
 func before_each():
@@ -40,3 +43,12 @@ func test_life_decrement_and_reload():
     assert_eq(manager.ui.lives, 1)
     manager.on_player_hit()
     assert_true(manager.ui.reload_called)
+
+func test_boss_defeated_triggers_next_level():
+    manager.boss = BossStub.new()
+    var called := false
+    manager.load_next_level = func():
+        called = true
+    manager._ready()
+    manager.boss.emit_signal("boss_defeated")
+    assert_true(called)


### PR DESCRIPTION
## Summary
- connect `Boss.boss_defeated` signal in `LevelManager`
- trigger level progression on boss defeat
- expand `test_level_manager` with boss signal mock

## Testing
- `godot --headless --quit -s tests/test_suite.gd` *(fails: command not found)*