### PR TITLE
Add projectile firing system with tests

### DIFF
--- a/scripts/MrPlus.gd
+++ b/scripts/MrPlus.gd
@@ -3,12 +3,16 @@ extends CharacterBody2D
 @export var speed := 120
 @export var jump_force := -300
 @export var gravity := 800
+@export var projectile_scene : PackedScene
 
 var velocity := Vector2.ZERO
+var _facing := 1
 
 func _physics_process(delta):
     var input := Input.get_action_strength("ui_right") - Input.get_action_strength("ui_left")
     velocity.x = input * speed
+    if input != 0:
+        _facing = sign(input)
 
     if not is_on_floor():
         velocity.y += gravity * delta
@@ -16,5 +20,12 @@ func _physics_process(delta):
         velocity.y = jump_force
         if has_node("JumpSound"):
             $JumpSound.play()
+
+    if Input.is_action_just_pressed("ui_attack") and projectile_scene:
+        var projectile = projectile_scene.instantiate()
+        if projectile.has_variable("direction"):
+            projectile.direction = Vector2(_facing, 0)
+        projectile.position = global_position
+        get_parent().add_child(projectile)
 
     velocity = move_and_slide(velocity, Vector2.UP)

--- a/scripts/PopcornProjectile.gd
+++ b/scripts/PopcornProjectile.gd
@@ -1,0 +1,15 @@
+extends Area2D
+
+@export var speed := 200
+var direction := Vector2.RIGHT
+
+func _physics_process(delta):
+    position += direction * speed * delta
+
+func _ready():
+    connect("body_entered", Callable(self, "_on_body_entered"))
+
+func _on_body_entered(body):
+    if body and body.has_method("take_damage"):
+        body.take_damage(1)
+    queue_free()

--- a/tests/test_mrplus.gd
+++ b/tests/test_mrplus.gd
@@ -8,6 +8,7 @@ func before_each():
     player.move_and_slide = func(v, up := Vector2.UP):
         return v
 
+
 func test_jump():
     player.is_on_floor = func(): return true
     Input.is_action_just_pressed = func(action):
@@ -21,3 +22,23 @@ func test_gravity():
     var dt := 0.5
     player._physics_process(dt)
     assert_eq(player.velocity.y, start_y + player.gravity * dt)
+
+func test_attack_spawns_projectile():
+    var parent = Node.new()
+    var added
+    parent.add_child = func(n):
+        added = n
+    player.get_parent = func():
+        return parent
+    var instance = Node2D.new()
+    var scene_stub = {
+        func instantiate():
+            return instance
+    }
+    player.projectile_scene = scene_stub
+    Input.is_action_just_pressed = func(action):
+        return action == "ui_attack"
+    Input.get_action_strength = func(action):
+        return 0
+    player._physics_process(0.016)
+    assert_eq(added, instance)

--- a/tests/test_popcorn_projectile.gd
+++ b/tests/test_popcorn_projectile.gd
@@ -1,0 +1,22 @@
+extends UnitTest
+
+func test_move_forward():
+    var p = preload("res://scripts/PopcornProjectile.gd").new()
+    p.speed = 100
+    p.direction = Vector2.RIGHT
+    p.position = Vector2.ZERO
+    p._physics_process(0.5)
+    assert_eq(p.position.x, 50)
+
+func test_damage_on_hit():
+    var p = preload("res://scripts/PopcornProjectile.gd").new()
+    var enemy = Node.new()
+    var damaged := false
+    enemy.take_damage = func(amount):
+        damaged = true
+    var freed := false
+    p.queue_free = func():
+        freed = true
+    p._on_body_entered(enemy)
+    assert_true(damaged)
+    assert_true(freed)

--- a/tests/test_suite.gd
+++ b/tests/test_suite.gd
@@ -4,3 +4,4 @@ func _init():
     add(preload("res://tests/test_mrplus.gd").new())
     add(preload("res://tests/test_enemy.gd").new())
     add(preload("res://tests/test_level_manager.gd").new())
+    add(preload("res://tests/test_popcorn_projectile.gd").new())


### PR DESCRIPTION
## Summary
- implement `PopcornProjectile` scene script for simple movement and collision
- expose a projectile scene in `MrPlus` and fire one on `ui_attack`
- create unit tests for projectile behaviour
- update player unit test to cover projectile spawning
- register new test file in the test suite

## Testing
- `godot --version` *(fails: command not found)*