### PR TITLE
Implement boss phases and tests

### DIFF
--- a/scripts/Boss.gd
+++ b/scripts/Boss.gd
@@ -1,27 +1,46 @@
 extends CharacterBody2D
 
 signal boss_defeated
+signal phase_changed
 
 @export var speed := 80
 @export var shoot_interval := 3.0
 @export var health := 20
 @export var projectile_scene : PackedScene
 
+@export var intro_duration := 1.0
+@export var rage_speed := 150
+@export var rage_shoot_interval := 1.0
+
+var phase := "intro"
 var _direction := 1
 var _shoot_timer := 0.0
+var _intro_timer := 0.0
+var _rage_threshold := 0
 
 func _ready():
+    _intro_timer = intro_duration
     _shoot_timer = shoot_interval
+    _rage_threshold = int(health / 2)
 
 func _physics_process(delta):
-    velocity.x = speed * _direction
+    if phase == "intro":
+        _intro_timer -= delta
+        if _intro_timer <= 0:
+            phase = "normal"
+            _shoot_timer = shoot_interval
+            emit_signal("phase_changed", phase)
+        return
+
+    var current_speed := speed if phase == "normal" else rage_speed
+    velocity.x = current_speed * _direction
     velocity = move_and_slide(velocity, Vector2.UP)
     if is_on_wall():
         _direction *= -1
 
     _shoot_timer -= delta
     if _shoot_timer <= 0:
-        _shoot_timer = shoot_interval
+        _shoot_timer = shoot_interval if phase == "normal" else rage_shoot_interval
         shoot()
 
 func shoot():
@@ -29,9 +48,17 @@ func shoot():
         var projectile = projectile_scene.instantiate()
         projectile.position = global_position
         get_parent().add_child(projectile)
+        if phase == "rage":
+            var projectile2 = projectile_scene.instantiate()
+            projectile2.position = global_position + Vector2(0, -16)
+            get_parent().add_child(projectile2)
 
 func take_damage(amount):
     health -= amount
+    if health <= _rage_threshold and phase == "normal":
+        phase = "rage"
+        _shoot_timer = rage_shoot_interval
+        emit_signal("phase_changed", phase)
     if health <= 0:
         emit_signal("boss_defeated")
         queue_free()

--- a/tests/test_boss.gd
+++ b/tests/test_boss.gd
@@ -1,0 +1,46 @@
+extends UnitTest
+
+var boss
+var phase_event
+var shots
+
+func before_each():
+    boss = preload("res://scripts/Boss.gd").new()
+    boss.intro_duration = 0.1
+    boss.shoot_interval = 1.0
+    boss.rage_shoot_interval = 0.5
+    boss.move_and_slide = func(v, up := Vector2.UP):
+        return v
+    boss.is_on_wall = func():
+        return false
+    shots = 0
+    boss.shoot = func():
+        shots += 1
+    phase_event = null
+    boss.connect("phase_changed", func(p): phase_event = p)
+
+func test_phase_transitions():
+    boss._ready()
+    boss._physics_process(0.05)
+    assert_eq(boss.phase, "intro")
+    boss._physics_process(0.05)
+    assert_eq(boss.phase, "normal")
+    assert_eq(phase_event, "normal")
+    boss.take_damage(boss.health / 2)
+    assert_eq(boss.phase, "rage")
+    assert_eq(phase_event, "rage")
+
+func test_projectile_timing_per_phase():
+    boss.intro_duration = 0
+    boss._ready()
+    boss._physics_process(0.4)
+    assert_eq(shots, 0)
+    boss._physics_process(0.6)
+    assert_eq(shots, 1)
+    boss._physics_process(1.0)
+    assert_eq(shots, 2)
+    boss.take_damage(boss.health / 2)
+    boss._physics_process(0.2)
+    assert_eq(shots, 2)
+    boss._physics_process(0.3)
+    assert_eq(shots, 3)

--- a/tests/test_suite.gd
+++ b/tests/test_suite.gd
@@ -4,3 +4,4 @@ func _init():
     add(preload("res://tests/test_mrplus.gd").new())
     add(preload("res://tests/test_enemy.gd").new())
     add(preload("res://tests/test_level_manager.gd").new())
+    add(preload("res://tests/test_boss.gd").new())


### PR DESCRIPTION
## Summary
- expand `Boss.gd` to include intro and rage phases
- adjust speed and shooting patterns based on phase
- emit `phase_changed` signal when phases shift
- add unit tests covering boss behaviour
- register boss tests in `test_suite`

## Testing
- `godot --headless -s tests/test_suite.gd` *(fails: command not found)*