### PR TITLE
Implement boss phases and tests

### DIFF
--- a/Main.tscn
+++ b/Main.tscn
@@ -1,0 +1,28 @@
+[gd_scene load_steps=8 format=3]
+
+[ext_resource path="res://scripts/LevelManager.gd" type="Script" id=1]
+[ext_resource path="res://scripts/MrPlus.gd" type="Script" id=2]
+[ext_resource path="res://scripts/Enemy.gd" type="Script" id=3]
+[ext_resource path="res://scripts/UI.gd" type="Script" id=4]
+[ext_resource path="res://assets/audio/jump.wav" type="AudioStream" id=5]
+
+[node name="Main" type="Node2D"]
+script = ExtResource(1)
+
+[node name="MrPlus" type="CharacterBody2D" parent="."]
+script = ExtResource(2)
+
+[node name="JumpSound" type="AudioStreamPlayer" parent="MrPlus"]
+stream = ExtResource(5)
+
+[node name="Enemy" type="CharacterBody2D" parent="."]
+script = ExtResource(3)
+
+[node name="UI" type="CanvasLayer" parent="."]
+script = ExtResource(4)
+
+[node name="ScoreLabel" type="Label" parent="UI"]
+text = "Popcorn: 0"
+
+[node name="LivesLabel" type="Label" parent="UI"]
+text = "Lives: 3"

--- a/scripts/Boss.gd
+++ b/scripts/Boss.gd
@@ -1,27 +1,46 @@
 extends CharacterBody2D
 
 signal boss_defeated
+signal phase_changed
 
 @export var speed := 80
 @export var shoot_interval := 3.0
 @export var health := 20
 @export var projectile_scene : PackedScene
 
+@export var intro_duration := 1.0
+@export var rage_speed := 150
+@export var rage_shoot_interval := 1.0
+
+var phase := "intro"
 var _direction := 1
 var _shoot_timer := 0.0
+var _intro_timer := 0.0
+var _rage_threshold := 0
 
 func _ready():
+    _intro_timer = intro_duration
     _shoot_timer = shoot_interval
+    _rage_threshold = int(health / 2)
 
 func _physics_process(delta):
-    velocity.x = speed * _direction
+    if phase == "intro":
+        _intro_timer -= delta
+        if _intro_timer <= 0:
+            phase = "normal"
+            _shoot_timer = shoot_interval
+            emit_signal("phase_changed", phase)
+        return
+
+    var current_speed := speed if phase == "normal" else rage_speed
+    velocity.x = current_speed * _direction
     velocity = move_and_slide(velocity, Vector2.UP)
     if is_on_wall():
         _direction *= -1
 
     _shoot_timer -= delta
     if _shoot_timer <= 0:
-        _shoot_timer = shoot_interval
+        _shoot_timer = shoot_interval if phase == "normal" else rage_shoot_interval
         shoot()
 
 func shoot():
@@ -29,9 +48,17 @@ func shoot():
         var projectile = projectile_scene.instantiate()
         projectile.position = global_position
         get_parent().add_child(projectile)
+        if phase == "rage":
+            var projectile2 = projectile_scene.instantiate()
+            projectile2.position = global_position + Vector2(0, -16)
+            get_parent().add_child(projectile2)
 
 func take_damage(amount):
     health -= amount
+    if health <= _rage_threshold and phase == "normal":
+        phase = "rage"
+        _shoot_timer = rage_shoot_interval
+        emit_signal("phase_changed", phase)
     if health <= 0:
         emit_signal("boss_defeated")
         queue_free()

--- a/scripts/LevelManager.gd
+++ b/scripts/LevelManager.gd
@@ -10,11 +10,14 @@ static var lives: int = 3
 
 @onready var player := $MrPlus
 @onready var ui := $UI
+@onready var boss := get_node_or_null("Boss")
 
 func _ready():
     # When a new level loads, sync the UI with the stored state
     ui.update_lives(lives)
     ui.update_score(score)
+    if boss:
+        boss.boss_defeated.connect(on_boss_defeated)
 
 func on_pipoca_collected():
     ui.add_score(1)
@@ -41,4 +44,7 @@ func load_next_level():
     get_tree().change_scene_to_file(next_scene_path)
 
 func on_level_completed():
+    load_next_level()
+
+func on_boss_defeated():
     load_next_level()

--- a/scripts/MrPlus.gd
+++ b/scripts/MrPlus.gd
@@ -3,12 +3,16 @@ extends CharacterBody2D
 @export var speed := 120
 @export var jump_force := -300
 @export var gravity := 800
+@export var projectile_scene : PackedScene
 
 var velocity := Vector2.ZERO
+var _facing := 1
 
 func _physics_process(delta):
     var input := Input.get_action_strength("ui_right") - Input.get_action_strength("ui_left")
     velocity.x = input * speed
+    if input != 0:
+        _facing = sign(input)
 
     if not is_on_floor():
         velocity.y += gravity * delta
@@ -16,5 +20,12 @@ func _physics_process(delta):
         velocity.y = jump_force
         if has_node("JumpSound"):
             $JumpSound.play()
+
+    if Input.is_action_just_pressed("ui_attack") and projectile_scene:
+        var projectile = projectile_scene.instantiate()
+        if projectile.has_variable("direction"):
+            projectile.direction = Vector2(_facing, 0)
+        projectile.position = global_position
+        get_parent().add_child(projectile)
 
     velocity = move_and_slide(velocity, Vector2.UP)

--- a/scripts/PopcornProjectile.gd
+++ b/scripts/PopcornProjectile.gd
@@ -1,0 +1,15 @@
+extends Area2D
+
+@export var speed := 200
+var direction := Vector2.RIGHT
+
+func _physics_process(delta):
+    position += direction * speed * delta
+
+func _ready():
+    connect("body_entered", Callable(self, "_on_body_entered"))
+
+func _on_body_entered(body):
+    if body and body.has_method("take_damage"):
+        body.take_damage(1)
+    queue_free()

--- a/tests/test_boss.gd
+++ b/tests/test_boss.gd
@@ -1,0 +1,46 @@
+extends UnitTest
+
+var boss
+var phase_event
+var shots
+
+func before_each():
+    boss = preload("res://scripts/Boss.gd").new()
+    boss.intro_duration = 0.1
+    boss.shoot_interval = 1.0
+    boss.rage_shoot_interval = 0.5
+    boss.move_and_slide = func(v, up := Vector2.UP):
+        return v
+    boss.is_on_wall = func():
+        return false
+    shots = 0
+    boss.shoot = func():
+        shots += 1
+    phase_event = null
+    boss.connect("phase_changed", func(p): phase_event = p)
+
+func test_phase_transitions():
+    boss._ready()
+    boss._physics_process(0.05)
+    assert_eq(boss.phase, "intro")
+    boss._physics_process(0.05)
+    assert_eq(boss.phase, "normal")
+    assert_eq(phase_event, "normal")
+    boss.take_damage(boss.health / 2)
+    assert_eq(boss.phase, "rage")
+    assert_eq(phase_event, "rage")
+
+func test_projectile_timing_per_phase():
+    boss.intro_duration = 0
+    boss._ready()
+    boss._physics_process(0.4)
+    assert_eq(shots, 0)
+    boss._physics_process(0.6)
+    assert_eq(shots, 1)
+    boss._physics_process(1.0)
+    assert_eq(shots, 2)
+    boss.take_damage(boss.health / 2)
+    boss._physics_process(0.2)
+    assert_eq(shots, 2)
+    boss._physics_process(0.3)
+    assert_eq(shots, 3)

--- a/tests/test_level_manager.gd
+++ b/tests/test_level_manager.gd
@@ -16,6 +16,9 @@ class UIStub:
         if lives <= 0:
             reload_called = true
 
+class BossStub:
+    signal boss_defeated
+
 var manager
 
 func before_each():
@@ -40,3 +43,12 @@ func test_life_decrement_and_reload():
     assert_eq(manager.ui.lives, 1)
     manager.on_player_hit()
     assert_true(manager.ui.reload_called)
+
+func test_boss_defeated_triggers_next_level():
+    manager.boss = BossStub.new()
+    var called := false
+    manager.load_next_level = func():
+        called = true
+    manager._ready()
+    manager.boss.emit_signal("boss_defeated")
+    assert_true(called)

--- a/tests/test_mrplus.gd
+++ b/tests/test_mrplus.gd
@@ -8,6 +8,7 @@ func before_each():
     player.move_and_slide = func(v, up := Vector2.UP):
         return v
 
+
 func test_jump():
     player.is_on_floor = func(): return true
     Input.is_action_just_pressed = func(action):
@@ -21,3 +22,23 @@ func test_gravity():
     var dt := 0.5
     player._physics_process(dt)
     assert_eq(player.velocity.y, start_y + player.gravity * dt)
+
+func test_attack_spawns_projectile():
+    var parent = Node.new()
+    var added
+    parent.add_child = func(n):
+        added = n
+    player.get_parent = func():
+        return parent
+    var instance = Node2D.new()
+    var scene_stub = {
+        func instantiate():
+            return instance
+    }
+    player.projectile_scene = scene_stub
+    Input.is_action_just_pressed = func(action):
+        return action == "ui_attack"
+    Input.get_action_strength = func(action):
+        return 0
+    player._physics_process(0.016)
+    assert_eq(added, instance)

--- a/tests/test_popcorn_projectile.gd
+++ b/tests/test_popcorn_projectile.gd
@@ -1,0 +1,22 @@
+extends UnitTest
+
+func test_move_forward():
+    var p = preload("res://scripts/PopcornProjectile.gd").new()
+    p.speed = 100
+    p.direction = Vector2.RIGHT
+    p.position = Vector2.ZERO
+    p._physics_process(0.5)
+    assert_eq(p.position.x, 50)
+
+func test_damage_on_hit():
+    var p = preload("res://scripts/PopcornProjectile.gd").new()
+    var enemy = Node.new()
+    var damaged := false
+    enemy.take_damage = func(amount):
+        damaged = true
+    var freed := false
+    p.queue_free = func():
+        freed = true
+    p._on_body_entered(enemy)
+    assert_true(damaged)
+    assert_true(freed)

--- a/tests/test_suite.gd
+++ b/tests/test_suite.gd
@@ -4,3 +4,5 @@ func _init():
     add(preload("res://tests/test_mrplus.gd").new())
     add(preload("res://tests/test_enemy.gd").new())
     add(preload("res://tests/test_level_manager.gd").new())
+    add(preload("res://tests/test_popcorn_projectile.gd").new())
+    add(preload("res://tests/test_boss.gd").new())


### PR DESCRIPTION
## Summary
- expand `Boss.gd` to include intro and rage phases
- restore projectile features and tests from `main`
- fix conflict in `test_suite.gd` to register all tests

## Testing
- `godot --headless -s tests/test_suite.gd` *(fails: command not found)*