### PR TITLE
Add initial level with new block and item scripts

### DIFF
--- a/Level1.tscn
+++ b/Level1.tscn
@@ -1,0 +1,57 @@
+[gd_scene load_steps=14 format=3]
+
+[ext_resource path="res://scripts/LevelManager.gd" type="Script" id=1]
+[ext_resource path="res://scripts/MrPlus.gd" type="Script" id=2]
+[ext_resource path="res://scripts/Enemy.gd" type="Script" id=3]
+[ext_resource path="res://scripts/UI.gd" type="Script" id=4]
+[ext_resource path="res://assets/audio/jump.wav" type="AudioStream" id=5]
+[ext_resource path="res://assets/audio/music.wav" type="AudioStream" id=6]
+[ext_resource path="res://Popcorn.tscn" type="PackedScene" id=7]
+[ext_resource path="res://scripts/Exit.gd" type="Script" id=8]
+[ext_resource path="res://scripts/DisappearingBlock.gd" type="Script" id=9]
+[ext_resource path="res://scripts/SurpriseBlock.gd" type="Script" id=10]
+
+[node name="Level1" type="Node2D"]
+script = ExtResource(1)
+levels = ["res://Level1.tscn"]
+
+[node name="Music" type="AudioStreamPlayer" parent="."]
+stream = ExtResource(6)
+autoplay = true
+
+[node name="MrPlus" type="CharacterBody2D" parent="."]
+script = ExtResource(2)
+position = Vector2(16, 200)
+
+[node name="JumpSound" type="AudioStreamPlayer" parent="MrPlus"]
+stream = ExtResource(5)
+
+[node name="Enemy" type="CharacterBody2D" parent="."]
+script = ExtResource(3)
+position = Vector2(400, 200)
+
+[node name="UI" type="CanvasLayer" parent="."]
+script = ExtResource(4)
+
+[node name="ScoreLabel" type="Label" parent="UI"]
+text = "Popcorn: 0"
+
+[node name="LivesLabel" type="Label" parent="UI"]
+text = "Lives: 3"
+
+[node name="Popcorn1" type="Area2D" parent="."]
+instance = ExtResource(7)
+position = Vector2(128, 180)
+
+[node name="Exit" type="Area2D" parent="."]
+script = ExtResource(8)
+position = Vector2(1024, 200)
+
+[node name="DisBlock1" type="StaticBody2D" parent="."]
+script = ExtResource(9)
+position = Vector2(256, 160)
+
+[node name="Surprise1" type="StaticBody2D" parent="."]
+script = ExtResource(10)
+position = Vector2(320, 160)
+popcorn_scene = ExtResource(7)

--- a/Popcorn.tscn
+++ b/Popcorn.tscn
@@ -1,0 +1,18 @@
+[gd_scene load_steps=4 format=3]
+
+[ext_resource path="res://scripts/Popcorn.gd" type="Script" id=1]
+[ext_resource path="res://assets/audio/collect.wav" type="AudioStream" id=2]
+
+[node name="Popcorn" type="Area2D"]
+script = ExtResource(1)
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="."]
+shape = RectangleShape2D {
+    extents = Vector2(8, 8)
+}
+
+[node name="CollectSound" type="AudioStreamPlayer" parent="."]
+stream = ExtResource(2)
+
+[node name="Sprite2D" type="Sprite2D" parent="."]
+texture = null

--- a/scripts/DisappearingBlock.gd
+++ b/scripts/DisappearingBlock.gd
@@ -1,0 +1,13 @@
+extends StaticBody2D
+
+var steps := 0
+
+func _ready():
+    connect("body_entered", Callable(self, "_on_body_entered"))
+
+func _on_body_entered(body):
+    if body.name == "MrPlus" or body is CharacterBody2D:
+        if body.velocity.y > 0:
+            steps += 1
+            if steps >= 2:
+                queue_free()

--- a/scripts/Exit.gd
+++ b/scripts/Exit.gd
@@ -1,0 +1,10 @@
+extends Area2D
+
+func _ready():
+    connect("body_entered", Callable(self, "_on_body_entered"))
+
+func _on_body_entered(body):
+    if body.name == "MrPlus" or body is CharacterBody2D:
+        var scene = get_tree().current_scene
+        if scene and scene.has_method("on_level_completed"):
+            scene.on_level_completed()

--- a/scripts/LevelManager.gd
+++ b/scripts/LevelManager.gd
@@ -23,6 +23,8 @@ func on_pipoca_collected():
     ui.add_score(1)
     # Preserve score between levels
     score = ui.score
+    if ui.score >= 10:
+        on_level_completed()
 
 func on_player_hit():
     ui.remove_life()
@@ -44,6 +46,7 @@ func load_next_level():
     get_tree().change_scene_to_file(next_scene_path)
 
 func on_level_completed():
+    print("Channel switched… Get ready for the next dimension!")
     load_next_level()
 
 func on_boss_defeated():

--- a/scripts/Popcorn.gd
+++ b/scripts/Popcorn.gd
@@ -1,0 +1,15 @@
+extends Area2D
+
+@export var collect_sound: AudioStreamPlayer
+
+func _ready():
+    connect("body_entered", Callable(self, "_on_body_entered"))
+
+func _on_body_entered(body):
+    if body.name == "MrPlus" or body is CharacterBody2D:
+        if collect_sound:
+            collect_sound.play()
+        var scene = get_tree().current_scene
+        if scene and scene.has_method("on_pipoca_collected"):
+            scene.on_pipoca_collected()
+        queue_free()

--- a/scripts/SurpriseBlock.gd
+++ b/scripts/SurpriseBlock.gd
@@ -1,0 +1,18 @@
+extends StaticBody2D
+
+@export var popcorn_scene : PackedScene
+var triggered := false
+
+func _ready():
+    connect("body_entered", Callable(self, "_on_body_entered"))
+
+func _on_body_entered(body):
+    if triggered:
+        return
+    if body.name == "MrPlus" or body is CharacterBody2D:
+        if body.velocity.y < 0 and body.global_position.y > global_position.y:
+            triggered = true
+            if popcorn_scene:
+                var popcorn = popcorn_scene.instantiate()
+                popcorn.position = global_position + Vector2(0, -16)
+                get_parent().add_child(popcorn)


### PR DESCRIPTION
## Summary
- implement Sofa World as `Level1.tscn`
- add Popcorn collectible scene
- add scripts for disappearing blocks, surprise blocks and exits
- connect popcorn collection and level completion logic in `LevelManager`

## Testing
- `godot --headless -s tests/test_suite.gd` *(fails: command not found)*