### PR TITLE
Add Godot CLI download step

### DIFF
--- a/.github/workflows/godot-ci.yml
+++ b/.github/workflows/godot-ci.yml
@@ -1,0 +1,23 @@
+name: Build Godot project
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Download Godot CLI
+        run: |
+          wget https://downloads.tuxfamily.org/godotengine/4.2.1/Godot_v4.2.1-stable_linux.x86_64.zip
+          unzip Godot_v4.2.1-stable_linux.x86_64.zip
+          mv Godot_v4.2.1-stable_linux.x86_64 godot
+          chmod +x godot
+
+      - name: Run tests
+        run: ./godot --headless -s tests/test_suite.gd

--- a/.github/workflows/godot-ci.yml
+++ b/.github/workflows/godot-ci.yml
@@ -14,10 +14,10 @@ jobs:
 
       - name: Download Godot CLI
         run: |
-          wget https://downloads.tuxfamily.org/godotengine/4.2.1/Godot_v4.2.1-stable_linux.x86_64.zip
-          unzip Godot_v4.2.1-stable_linux.x86_64.zip
-          mv Godot_v4.2.1-stable_linux.x86_64 godot
-          chmod +x godot
+          curl -L -o godot.zip https://github.com/godotengine/godot/releases/download/4.2.1-stable/Godot_v4.2.1-stable_linux.x86_64.zip
+    unzip godot.zip
+    mv Godot_v4.2.1-stable_linux.x86_64 godot
+    chmod +x godot
 
       - name: Run tests
         run: ./godot --headless -s tests/test_suite.gd


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to run tests
- download Godot CLI before tests

## Testing
- `bash -c 'godot --version'` *(fails: command not found)*